### PR TITLE
[v1.2.1] Complete rewrite for breaking update

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,21 +5,38 @@ const { inject, uninject } = require('powercord/injector');
 
 module.exports = class QuickDelete extends Plugin {
   async startPlugin () {
-    this.messageClasses = (await getModule([ 'container', 'messageCompact' ]));
-    this.messageQuery = `.${this.messageClasses.content.replace(/ /g, '.')}`;
+    this.messageClasses = await getModule([ 'container', 'messageCompact' ]);
+    this.messageQuery = `.${this.messageClasses.container.split(' ')[0]} > div`;
+    this.patchReportMessage();
     this.patchMessageContent();
   }
 
   pluginWillUnload () {
-    uninject('pc-quickDelete-MessageContent');
+    const report = getModule([ 'canReportInChannel' ], false);
+    report.canReportMessage = report.__canReportMessage;
+
+    uninject('quickDelete-MessageContent');
     forceUpdateElement(this.messageQuery, true);
+  }
+
+  async patchReportMessage () {
+    const report = await getModule([ 'canReportInChannel' ]);
+    const id = (await getModule([ 'getId' ])).getId();
+
+    report.canReportMessage = (canReportMessage => (message) => {
+      if (message && message.author.id !== id) {
+        return true;
+      }
+
+      return canReportMessage(message);
+    })(report.__canReportMessage = report.canReportMessage);
   }
 
   async patchMessageContent () {
     const _this = this;
     const instance = getOwnerInstance(await waitFor(this.messageQuery));
 
-    const permissions = (await getModule([ 'getChannelPermissions' ]));
+    const permissions = await getModule([ 'getChannelPermissions' ]);
     const currentUser = (await getModule([ 'getCurrentUser' ])).getCurrentUser();
 
     function renderMessage (_, res) {
@@ -27,20 +44,46 @@ module.exports = class QuickDelete extends Plugin {
       const hasDeletePermission = permissions.can(Permissions.MANAGE_MESSAGES, channel);
 
       if (hasDeletePermission || message.author.id === currentUser.id) {
-        res.props.onClick = _this.handleMessageDelete(channel.id, message.id);
+        res.props.onClick = _this.handleMessageDelete(channel, message);
       }
 
       return res;
     }
 
-    inject('pc-quickDelete-MessageContent', instance.__proto__, 'render', renderMessage);
+    inject('quickDelete-MessageContent', instance.__proto__, 'render', renderMessage);
     forceUpdateElement(this.messageQuery, true);
   }
 
-  handleMessageDelete (channelId, messageId) {
+  handleMessageDelete (channel, message) {
+    let isHoldingDelete = false;
+    document.addEventListener('keydown', (e) => {
+      if (e.key === 'Delete') {
+        isHoldingDelete = true;
+      }
+    });
+
+    document.addEventListener('keyup', (e) => {
+      if (e.key === 'Delete') {
+        isHoldingDelete = false;
+      }
+    });
+
+    messages.confirmDelete = getModule([ 'confirmDelete' ], false).confirmDelete;
+
     return (e) => {
-      if (e.ctrlKey) {
-        messages.deleteMessage(channelId, messageId, false);
+      if ((e.shiftKey && e.ctrlKey) || isHoldingDelete) {
+        messages.deleteMessage(channel.id, message.id, false);
+      } else if (e.ctrlKey) {
+        messages.confirmDelete(channel, message, true);
+
+        const tipClass = `.${getModule([ 'inline', 'tip' ], false).tip.split(' ')[0]}`;
+
+        setTimeout(() => {
+          const tip = document.querySelector(tipClass);
+          if (tip) {
+            tip.innerHTML = 'You can hold down shift before clicking a message that you want to delete to bypass this confirmation entirely.';
+          }
+        }, 100);
       }
     };
   }

--- a/index.js
+++ b/index.js
@@ -1,14 +1,40 @@
 const { Plugin } = require('powercord/entities');
-const { forceUpdateElement, getOwnerInstance, waitFor } = require('powercord/util');
 const { getModule, messages, constants: { Permissions } } = require('powercord/webpack');
+const { forceUpdateElement } = require('powercord/util');
 const { inject, uninject } = require('powercord/injector');
 
 module.exports = class QuickDelete extends Plugin {
+  constructor () {
+    super();
+
+    this.state = {
+      hoveredMessage: null,
+      isHoldingDelete: false
+    };
+  }
+
   async startPlugin () {
-    this.messageClasses = await getModule([ 'container', 'messageCompact' ]);
-    this.messageQuery = `.${this.messageClasses.container.split(' ')[0]} > div`;
+    this.messageClasses = await getModule([ 'messages', 'scroller' ]);
+    this.deleteListener = (e) => {
+      if (e.key === 'Delete') {
+        if (this.state.isHoldingDelete) {
+          return this.state.isHoldingDelete = false;
+        }
+
+        this.state.isHoldingDelete = true;
+
+        if (this.state.hoveredMessage) {
+          const { hoveredMessage } = this.state;
+          this.handleMessageDelete(hoveredMessage.channel, hoveredMessage.message).call(this, e);
+        }
+      }
+    };
+
     this.patchReportMessage();
     this.patchMessageContent();
+
+    document.addEventListener('keydown', this.deleteListener);
+    document.addEventListener('keyup', this.deleteListener);
   }
 
   pluginWillUnload () {
@@ -16,7 +42,10 @@ module.exports = class QuickDelete extends Plugin {
     report.canReportMessage = report.__canReportMessage;
 
     uninject('quickDelete-MessageContent');
-    forceUpdateElement(this.messageQuery, true);
+    forceUpdateElement(`.${this.messageClasses.message}`, true);
+
+    document.removeEventListener('keydown', this.deleteListener);
+    document.removeEventListener('keyup', this.deleteListener);
   }
 
   async patchReportMessage () {
@@ -33,55 +62,47 @@ module.exports = class QuickDelete extends Plugin {
   }
 
   async patchMessageContent () {
-    const _this = this;
-    const instance = getOwnerInstance(await waitFor(this.messageQuery));
-
     const permissions = await getModule([ 'getChannelPermissions' ]);
     const currentUser = (await getModule([ 'getCurrentUser' ])).getCurrentUser();
 
-    function renderMessage (_, res) {
-      const { message, channel } = this.props;
+    const renderMessage = (args, res) => {
+      const { childrenAccessories: { props: { message, channel } } } = args[0];
       const hasDeletePermission = permissions.can(Permissions.MANAGE_MESSAGES, channel);
 
       if (hasDeletePermission || message.author.id === currentUser.id) {
-        res.props.onClick = _this.handleMessageDelete(channel, message);
+        res.props.onClick = this.handleMessageDelete(channel, message);
+        res.props.onMouseOver = () => this.state.hoveredMessage = { channel, message };
+        res.props.onMouseLeave = () => this.state.hoveredMessage = null;
       }
 
       return res;
-    }
+    };
 
-    inject('quickDelete-MessageContent', instance.__proto__, 'render', renderMessage);
-    forceUpdateElement(this.messageQuery, true);
+    const Message = await getModule(m => m.default && m.default.displayName === 'Message');
+    inject('quickDelete-MessageContent', Message, 'default', renderMessage);
+
+    Message.default.displayName = 'Message';
+
+    forceUpdateElement(`.${this.messageClasses.message}`, true);
   }
 
   handleMessageDelete (channel, message) {
-    let isHoldingDelete = false;
-    document.addEventListener('keydown', (e) => {
-      if (e.key === 'Delete') {
-        isHoldingDelete = true;
-      }
-    });
-
-    document.addEventListener('keyup', (e) => {
-      if (e.key === 'Delete') {
-        isHoldingDelete = false;
-      }
-    });
-
     messages.confirmDelete = getModule([ 'confirmDelete' ], false).confirmDelete;
 
     return (e) => {
-      if ((e.shiftKey && e.ctrlKey) || isHoldingDelete) {
+      if (e.shiftKey && e.ctrlKey) {
         messages.deleteMessage(channel.id, message.id, false);
-      } else if (e.ctrlKey) {
-        messages.confirmDelete(channel, message, true);
+      } else if (e.ctrlKey || this.state.isHoldingDelete) {
+        messages.confirmDelete(channel, message, e.ctrlKey);
 
         const tipClass = `.${getModule([ 'inline', 'tip' ], false).tip.split(' ')[0]}`;
 
         setTimeout(() => {
           const tip = document.querySelector(tipClass);
+
           if (tip) {
-            tip.innerHTML = 'You can hold down shift before clicking a message that you want to delete to bypass this confirmation entirely.';
+            tip.innerHTML = 'You can hold down shift before clicking a message that you want ' +
+            'to delete to bypass this confirmation entirely.';
           }
         }, 100);
       }

--- a/manifest.json
+++ b/manifest.json
@@ -1,6 +1,6 @@
 {
-  "name": "Quickdelete",
-  "version": "1.2.0",
+  "name": "quickDelete",
+  "version": "1.2.1",
   "description": "Quickly delete messages by holding 'Ctrl' or 'Delete' and clicking on a message.",
   "author": "Ghostly. (+ Harley#1051)",
   "license": "GPLv3"

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
-    "name": "Quickdelete",
-    "version": "1.1.0",
-    "description": "Quickly delete messages using CTRL+Click on a message",
-    "author": "Ghostly. (+ Harley#1051)",
-    "license": "GPLv3"
+  "name": "Quickdelete",
+  "version": "1.2.0",
+  "description": "Quickly delete messages by holding 'Ctrl' or 'Delete' and clicking on a message.",
+  "author": "Ghostly. (+ Harley#1051)",
+  "license": "GPLv3"
 }


### PR DESCRIPTION
* Holding down the 'Ctrl' key alone will now display a confirmation modal, however it can be skipped if the 'Shift' key is also held down.
* Message deletions can now be staged with the 'Delete' key which will in turn bring up the aforementioned confirmation modal.
* Provide an option in the confirmation modal to report the selected message to Discord's Trust & Safety Team before deleting a message.
* Bump version number from '1.1.0' to '1.2.1'.